### PR TITLE
Fix error scrolling on other panes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.1.0 - First Release
+## 0.2.0 - First Release
 * Every feature added
 * Every bug fixed

--- a/lib/atom-touch-events.coffee
+++ b/lib/atom-touch-events.coffee
@@ -47,7 +47,7 @@ module.exports = AtomTouchEvents =
   # Touch points have been updated. Determine if constitutes a swipe,
   # and then update the reference points.
   handleTouchMove: (args) ->
-    source = args.srcElement.getModel()
+    source = args.srcElement
 
     deltaX = args.touches[0].pageY - AtomTouchEvents.startY
     deltaY = args.touches[0].pageX - AtomTouchEvents.startX

--- a/lib/atom-touch-scroll.coffee
+++ b/lib/atom-touch-scroll.coffee
@@ -3,6 +3,10 @@ AtomTouchEvents = require './atom-touch-events'
 module.exports = AtomTouchScroll =
 
     activate: () ->
+
+      # Factor to multiply delta amount by to scroll.
+      @scrollFactor = 5
+
       AtomTouchEvents.onDidTouchSwipeUp(@touchScrollUp)
       AtomTouchEvents.onDidTouchSwipeDown(@touchScrollDown)
 
@@ -10,18 +14,18 @@ module.exports = AtomTouchScroll =
     touchScrollUp: (args) ->
       {source, deltaX, deltaY} = args
 
-      for textEditor in atom.workspace.getTextEditors()
-        if source == textEditor
-          # Determine amount to scroll based on delta value with a factor of 5.
-          amount = Math.abs(deltaY) * 5
-          source.setScrollTop(source.getScrollTop() + amount)
+      if source?.nodeName.toLowerCase() is 'atom-text-editor'
+        editor = source.getModel()
+        # Determine amount to scroll based on delta value with a factor of 5.
+        amount = Math.abs(deltaY) * @scrollFactor
+        editor.setScrollTop(editor.getScrollTop() + amount)
 
     # Scrolls down, based on touch event deltas.
     touchScrollDown: (args) ->
       {source, deltaX, deltaY} = args
 
-      for textEditor in atom.workspace.getTextEditors()
-        if source == textEditor
-          # Determine amount to scroll based on delta value with a factor of 5.
-          amount = Math.abs(deltaY) * 5
-          source.setScrollTop(source.getScrollTop() - amount)
+      if source?.nodeName.toLowerCase() is 'atom-text-editor'
+        editor = source.getModel()
+        # Determine amount to scroll based on delta value with a factor of 5.
+        amount = Math.abs(deltaY) * @scrollFactor
+        editor.setScrollTop(editor.getScrollTop() - amount)


### PR DESCRIPTION
Fixes #1.

Returns view object from event (instead of model), and updates scroll behaviour to check if text editor element, then get model to scroll.

