### PR TITLE
Fix touchend event

### DIFF
--- a/lib/atom-touch-events.coffee
+++ b/lib/atom-touch-events.coffee
@@ -71,7 +71,9 @@ module.exports = AtomTouchEvents =
   # Set the initial set of points for touch events.
   # These will be used to determine deltas.
   handleTouchStart: (args) ->
-    AtomTouchEvents.currentArgs = args
+    # set both to prevent exceptions in getDeltaForIndex, getStartDistance
+    # and getCurrentDistance when no touchmove is triggered before touchend
+    AtomTouchEvents.startArgs = AtomTouchEvents.currentArgs = args
 
   # Touch points have been updated. Determine if constitutes a swipe,
   # and then update the reference points.
@@ -111,10 +113,6 @@ module.exports = AtomTouchEvents =
 
   handleTouchEnd: (args) ->
     source = args.srcElement
-
-    # Store previous arguments for comparison of move.
-    AtomTouchEvents.startArgs = AtomTouchEvents.currentArgs
-    AtomTouchEvents.currentArgs = args
 
     elapsedTime = args.timeStamp - AtomTouchEvents.currentArgs.timeStamp
 


### PR DESCRIPTION
The `touchend` event is passed the same `changedTouches` as the last `touchmove` event. So when calculating the delta between them, it will always return `0`, and so none of the `*-end` event handlers will be called.

It now sets both `startArgs` and `currentArgs` in the `touchstart` handler, to prevent exceptions on tap events where no `touchmove` was triggered (and thus `startArgs` wouldn't exist yet)