### PR TITLE
Single service provider for all events

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ To consume these events, add the following to your package.json (or the services
 
 ```
 "consumedServices": {
-  "touch-swipe-left-service": {
+  "touch-events": {
     "versions": {
-      "^0.12.0": "consumeOnDidTouchSwipeLeft"
+      "^0.21.0": "consumeTouchEvents"
     }
 }
 ```
@@ -42,9 +42,9 @@ To consume these events, add the following to your package.json (or the services
 Then in your main package, implement your consumer function to use the service function:
 
 ```
-consumeOnDidTouchSwipeLeft: (onDidTouchSwipeLeft) ->
+consumeTouchEvents: (touchEvents) ->
 
-  # Subscribe to touch event
-  onDidTouchSwipeLeft: (event) ->
-    console.log "Swiped Left!"
-    ```
+  # Subscribe to touch swipe left event
+  touchEvents.onDidTouchSwipeLeft (event) ->
+    console.log "Swiped left!"
+```

--- a/README.md
+++ b/README.md
@@ -30,18 +30,19 @@ For more information about consuming these services in your package, read here: 
 
 To consume these events, add the following to your package.json (or the services you need):
 
-```
+```json
 "consumedServices": {
   "touch-events": {
     "versions": {
       "^0.21.0": "consumeTouchEvents"
     }
+  }
 }
 ```
 
 Then in your main package, implement your consumer function to use the service function:
 
-```
+```coffee
 consumeTouchEvents: (touchEvents) ->
 
   # Subscribe to touch swipe left event

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -38,3 +38,12 @@ module.exports = Main =
   # Touch tap gesture
   onDidTouchTap: ->
     AtomTouchEvents.onDidTouchTap
+
+  provideTouchEvents: ->
+    onDidTouchSwipeDown:  AtomTouchEvents.onDidTouchSwipeDown
+    onDidTouchSwipeUp:    AtomTouchEvents.onDidTouchSwipeUp
+    onDidTouchSwipeLeft:  AtomTouchEvents.onDidTouchSwipeLeft
+    onDidTouchSwipeRight: AtomTouchEvents.onDidTouchSwipeRight
+    onDidTouchPinchIn:    AtomTouchEvents.onDidTouchPinchIn
+    onDidTouchPinchOut:   AtomTouchEvents.onDidTouchPinchOut
+    onDidTouchTap:        AtomTouchEvents.onDidTouchTap

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
       "versions": {
         "0.20.0": "onDidTouchTap"
       }
+    },
+    "touch-events": {
+      "versions": {
+        "0.21.0": "provideTouchEvents"
+      }
     }
   },
   "readme": "# atom-touch-events package\r\n\r\nThis package provides touchscreen event handling and gesture capability.\r\n\r\nThis package exposes the events listed below as part of Atom Services.\r\n\r\n### Supported behaviours\r\n* Touch-based scrolling (horizontal and vertical) for Text Editors\r\n* Touch-based zooming (font size adjustment) for Text Editors\r\n\r\n### Supported gesture events\r\n* AtomTouchEvents.onDidTouchSwipeUp\r\n* AtomTouchEvents.onDidTouchSwipeDown\r\n* AtomTouchEvents.onDidTouchSwipeLeft\r\n* AtomTouchEvents.onDidTouchSwipeRight\r\n* AtomTouchEvents.onDidTouchPinchIn\r\n* AtomTouchEvents.onDidTouchPinchOut\r\n\r\n### Plans\r\n* Add more gestures (tap)\r\n* Add more behaviours (more granular pinch to zoom)\r\n* Fix TreeView touch-related issues\r\n\r\n### How To Consume Atom Touch Events\r\n\r\nThe Atom Service Provider API is used to provide versioned services of these events.\r\n\r\nFor more information about consuming these services in your package, read here: https://atom.io/docs/latest/behind-atom-interacting-with-packages-via-services.\r\n\r\nTo consume these events, add the following to your package.json (or the services you need):\r\n\r\n```\r\n\"consumedServices\": {\r\n  \"touch-swipe-left-service\": {\r\n    \"versions\": {\r\n      \"^0.12.0\": \"consumeOnDidTouchSwipeLeft\"\r\n    }\r\n}\r\n```\r\n\r\nThen in your main package, implement your consumer function to use the service function:\r\n\r\n```\r\nconsumeOnDidTouchSwipeLeft: (onDidTouchSwipeLeft) ->\r\n\r\n  # Subscribe to touch event\r\n  onDidTouchSwipeLeft: (event) ->\r\n    console.log \"Swiped Left!\"\r\n    ```\r\n",


### PR DESCRIPTION
This PR combines the multiple services provided by atom-touch-events into a single service, mostly for package authors' convenience. Instead of having to add a single entry for each event in `package.json` and in the javascript, consumers can now listen to a single service and just use the functions they need.

In package.json:

```json
"consumedServices": {
  "touch-events": {
    "versions": {
      "0.21.0": "consumeTouchEvents"
    }
  }
}
```

In package's main module:

```coffee
module.exports =
  # ...

  consumeTouchEvents: (@touchEventsService) ->
    @touchEventsService.onDidTouchSwipeUp upCallback
    @touchEventsService.onDidTouchSwipeDown downCallback
```